### PR TITLE
feat: no longer require var-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ a pre-commit hook for finding unused variables in terraform modules and removing
 ```
   -h, --help           show this help message and exit
   --dir DIR            root dir to search for tf files in (default: ".")
-  --var-file VAR_FILE  file name for where tf variables are defined (default: "variables.tf")
   --check-only         flag to only check for unused vars, not remove them
   -r, --recursive      flag to run check unused variables recursively on all directories from root dir
   --ignore IGNORE_TXT  text in variable declaration comment used to tell the hook to ignore a specific unused
@@ -26,11 +25,11 @@ repos:
     rev: v1.2.1
     hooks:
     -   id: check-unused-vars
-        args: [-r, --dir=., --var-file=variables.tf]
+        args: [-r, --dir=.]
 ```
 ### Assumptions
 
-This pre-commit hook assumes standard terraform practices where all variables are declared in a single file for a module and that variables are declared with no leading white space on the keyword or before the closing curly brace.
+This pre-commit hook assumes standard terraform practices such as: variables are declared with no leading white space on the keyword or before the closing curly brace.
 
 ex: variables.tf
 ```hcl

--- a/terraform-check-unused-variables.py
+++ b/terraform-check-unused-variables.py
@@ -6,7 +6,6 @@ Scan terraform module(s) for unused variables and remove them.
 optional arguments:
   -h, --help           show this help message and exit
   --dir DIR            root dir to search for tf files in (default: ".")
-  --var-file VAR_FILE  file name for where tf variables are defined (default: "variables.tf")
   -r, --recursive      flag to run check unused variables recursively on all directories from root dir
   --check-only         flag to only check for unused vars, not remove them
   --verbose, -v        flag to show verbose (debug) output
@@ -23,19 +22,17 @@ from glob import glob
 
 def check_for_unused_vars(dir):
     try:
-        variables_file, all_tf_files = find_tf_files(dir)
-        if variables_file is None:
-            return True  # no files to check in this directory
+        tf_files = find_tf_files(dir)
         logging.info(f'Checking {dir} for unused variables')
-        variables = parse_variables_tf(variables_file)
-        var_references = find_used_variables(all_tf_files)
+        variables = parse_variables_tf(tf_files)
+        var_references = find_used_variables(tf_files)
         unused_vars = list(variables - var_references)
 
         if len(unused_vars) > 0:
             logging.info('unused vars detected:')
             logging.info("%s\n" % unused_vars)
             if not args.check_only:
-                remove_unused_vars(unused_vars, variables_file)
+                remove_unused_vars(unused_vars, tf_files)
             return False
         else:
             logging.info('no unused variables found')
@@ -46,51 +43,44 @@ def check_for_unused_vars(dir):
 
 
 def find_tf_files(_dir):
-    try:
-        target_dir = os.getcwd() + "/" + _dir.replace(".", '')
-        all_tf_files = glob(os.path.join(_dir, '*.tf'))
-        logging.debug(f'tf files: {all_tf_files}')
 
-        if len(all_tf_files) < 1:
-            logging.info(f'Did not find any tf files in {target_dir}\nEnsure running '
-                         'from root terraform module or correct custom dir.\n\nTo set custom dir use --dir PATH')
-            return None, None
+    target_dir = os.getcwd() + "/" + _dir.replace(".", '')
+    all_tf_files = glob(os.path.join(_dir, '*.tf'))
+    logging.debug(f'tf files: {all_tf_files}')
 
-        variables_file = glob(os.path.join(_dir, '*' + args.var_file))[0]
-        logging.debug(f'variable file: {variables_file}')
+    if len(all_tf_files) < 1:
+        logging.info(f'Did not find any tf files in {target_dir}\nEnsure running '
+                     'from root terraform module or correct custom dir.\n\nTo set custom dir use --dir PATH')
+        return None, None
 
-        return variables_file, all_tf_files
-    except IndexError:
-        raise IndexError(f'Failed to find required variable file "{args.var_file}" in {target_dir}, but did find other '
-                        'tf files.\nEnsure running from root terraform module or correct custom dir and the variable '
-                        'tf file exists.\n\nTo set custom dir use --dir PATH\nTo set custom var_file --var-file '
-                        'FILENAME\n')
+    return all_tf_files
 
 
-def remove_unused_vars(unused_vars, var_file):
-    removing_variable = False
-    with open(var_file, 'r') as file:
-        lines = file.readlines()
-        for i, line in enumerate(lines):
-            if removing_variable:
-                if line.startswith('}'):
-                    removing_variable = False
-                    if remove_trailing_new_line(i, lines):
-                        lines[i + 1] = ''
-                lines[i] = ''
-            elif line.startswith('variable'):
-                variable = strip_var_name(line)
-                if variable in unused_vars:
-                    if var_is_ignored(i, lines):
-                        logging.info('ignore flag detected, skipping...' + variable)
-                    else:
-                        lines[i] = ''
-                        removing_variable = True
-                        logging.info('removing...' + variable)
-                        lines = remove_preceding_comments(i, lines)
+def remove_unused_vars(unused_vars, tf_files):
+    for file in tf_files:
+        removing_variable = False
+        with open(file, 'r') as f:
+            lines = f.readlines()
+            for i, line in enumerate(lines):
+                if removing_variable:
+                    if line.startswith('}'):
+                        removing_variable = False
+                        if remove_trailing_new_line(i, lines):
+                            lines[i + 1] = ''
+                    lines[i] = ''
+                elif line.startswith('variable'):
+                    variable = strip_var_name(line)
+                    if variable in unused_vars:
+                        if var_is_ignored(i, lines):
+                            logging.info('ignore flag detected, skipping...' + variable)
+                        else:
+                            lines[i] = ''
+                            removing_variable = True
+                            logging.info('removing...' + variable)
+                            lines = remove_preceding_comments(i, lines)
 
-    with open(var_file, 'w') as file:
-        file.write(''.join(lines))
+            with open(file, 'w') as wf:
+                wf.write(''.join(lines))
 
 
 def remove_preceding_comments(i, lines):
@@ -116,9 +106,6 @@ def find_used_variables(tf_files):
     referenced_vars = []
     logging.debug(f'searching for unused vars')
     for tf_file in tf_files:
-        if 'variables.tf' in tf_file:
-            logging.debug(f'skipping {args.var_file}')
-            continue
         logging.debug(f'searching for var references in {tf_file}...')
         with open(tf_file, 'r') as file:
             lines = file.read()
@@ -131,15 +118,16 @@ def find_used_variables(tf_files):
     return set(referenced_vars)
 
 
-def parse_variables_tf(var_file):
+def parse_variables_tf(tf_files):
     declared_vars = set()
-    logging.debug(f'scanning {args.var_file} for all defined vars')
-    with open(var_file, 'r') as file:
-        lines = file.readlines()
-        for line in lines:
-            if line.startswith('variable'):
-                declared_vars.add(strip_var_name(line))
-    logging.debug(f'all declared vars: {declared_vars}')
+    for file in tf_files:
+        logging.debug(f'scanning {file} for all defined vars')
+        with open(file, 'r') as f:
+            lines = f.readlines()
+            for line in lines:
+                if line.startswith('variable'):
+                    declared_vars.add(strip_var_name(line))
+        logging.debug(f'all declared vars: {declared_vars}')
     return declared_vars
 
 
@@ -154,10 +142,6 @@ def parse_args():
                         dest='dir',
                         default='.',
                         help='root dir to search for tf files in (default: ".")')
-    parser.add_argument('--var-file',
-                        dest='var_file',
-                        default='variables.tf',
-                        help='file name for where tf variables are defined (default: "variables.tf")')
     parser.add_argument('--check-only',
                         dest='check_only',
                         default=False,


### PR DESCRIPTION
var-file depended on a variables.tf file or 'some file' where all the variables lived. although a best practice, this led to some users having errors since they had everything in one file, or variable declarations hidden across multiple files.

since the purpose of this pre-commit hook is to find and remove unused variables, not enforce terraform best practices, the assumption that there is a variables.tf file and that all variables live there is removed in this commit.

```bash
===============================================================================
=============================    Running tests    =============================
===============================================================================

dir test 1...pass
dir test 2...pass
recursive test 1...pass
recursive test 2...pass
ignore test 1...pass
ignore test 2...pass
```